### PR TITLE
Fix bug preventing adding orders at same datetime

### DIFF
--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -109,19 +109,13 @@ public class Order implements Item, Aggregator<Dish> {
         return false;
     }
 
+    /**
+     * Two orders are only the same if every one of their fields matches.
+     * Otherwise, they are different orders.
+     */
     @Override
     public boolean isSame(Item other) {
-        if (other == this) {
-            return true;
-        }
-
-        if (!(other instanceof Order)) {
-            return false;
-        }
-
-        Order otherOrder = (Order) other;
-        return otherOrder != null
-                && this.getStrDatetime().equals(otherOrder.getStrDatetime());
+        return this.equals(other);
     }
 
     @Override


### PR DESCRIPTION
Current code detects duplicate order if a new order has the same datetime as an existing order.

Fixed by redefining sameness to require equality in all three fields.