### PR TITLE
add warning before cascading deletion of customer

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -54,8 +54,10 @@ contacts add n/[NAME] p/[PHONE_NUMBER] e/[EMAIL] a/[ADDRESS]
 #### `delete` - Delete contact
 Format:
 ```
-contacts delete [INDEX]
+contacts delete [INDEX] [-f]
 ```
+
+In the event that there are unfulfilled orders by the contact that is being attempted to be deleted, a `-f` flag has to be added to the end of the command to confirm the command. This is to prevent you from accidentally deleting orders unknowingly and leading to unhappy customers!
 
 #### `find` - Find contact
 Format:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -37,24 +37,24 @@ Format: `help`
 #### `exit` - Exit application
 Format: `exit`
 
-### `contacts`
+### `customer`
 
-#### `list` - List all contacts
+#### `list` - List all customers
 Format: 
 ```
-contacts list
+customer list
 ```
 
-#### `add` - Add a contact
+#### `add` - Add a customers
 Format: 
 ```
-contacts add n/[NAME] p/[PHONE_NUMBER] e/[EMAIL] a/[ADDRESS]
+customer add n/[NAME] p/[PHONE_NUMBER] e/[EMAIL] a/[ADDRESS]
 ```
 
-#### `delete` - Delete contact
+#### `delete` - Delete customer
 Format:
 ```
-contacts delete [INDEX] [-f]
+customer delete [INDEX] (-f)
 ```
 
 In the event that there are unfulfilled orders by the contact that is being attempted to be deleted, a `-f` flag has to be added to the end of the command to confirm the command. This is to prevent you from accidentally deleting orders unknowingly and leading to unhappy customers!
@@ -62,7 +62,7 @@ In the event that there are unfulfilled orders by the contact that is being atte
 #### `find` - Find contact
 Format:
 ```
-contacts find n/[KEYWORD] [MORE KEYWORDS]
+customer find n/[KEYWORD] [MORE KEYWORDS]
 ```
 
 ### `menu`

--- a/src/main/java/seedu/address/logic/commands/customer/CustomerDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/customer/CustomerDeleteCommand.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
 /**
@@ -26,11 +27,21 @@ public class CustomerDeleteCommand extends Command {
             + "Example: " + COMPONENT_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_FAILURE =
+            "Failed to deleted cusomter: %1 due to outstanding orders, "
+                    + "add -f flag to force delete the cusomter\n"
+                    + "Warning: This will delete any order that contains %1";
 
     private final Index targetIndex;
+    private final boolean isForce;
 
     public CustomerDeleteCommand(Index targetIndex) {
+        this(targetIndex, false);
+    }
+
+    public CustomerDeleteCommand(Index targetIndex, boolean isForce) {
         this.targetIndex = targetIndex;
+        this.isForce = isForce;
     }
 
     @Override
@@ -44,10 +55,17 @@ public class CustomerDeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        List<Order> outstandingOrders = model.getIncompleteOrdersFromPerson(personToDelete);
+        boolean isOutstandingOrders = !outstandingOrders.isEmpty();
+
+        if (isOutstandingOrders && !isForce) {
+            throw new CommandException(String.format(MESSAGE_DELETE_PERSON_FAILURE, personToDelete.getName()));
+        }
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete),
                 CommandResult.CRtype.PERSON);
-
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/customer/CustomerDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/customer/CustomerDeleteCommand.java
@@ -39,6 +39,11 @@ public class CustomerDeleteCommand extends Command {
         this(targetIndex, false);
     }
 
+    /**
+     * Delete customer given index and isForce flag
+     * @param targetIndex index of customer to be deleted
+     * @param isForce required to be true if there are outstanding orders that will also be deleted
+     */
     public CustomerDeleteCommand(Index targetIndex, boolean isForce) {
         this.targetIndex = targetIndex;
         this.isForce = isForce;

--- a/src/main/java/seedu/address/logic/commands/menu/MenuDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/menu/MenuDeleteCommand.java
@@ -40,9 +40,9 @@ public class MenuDeleteCommand extends Command {
     }
 
     /**
-     * Mark order as cancelled with given index along with associated dishes
-     * @param targetIndex index in menu list
-     * @param isForce forces delete a dish
+     * Delete dish given index and isForce flag
+     * @param targetIndex index of dish to be deleted
+     * @param isForce required to be true if there are outstanding orders that will also be cancelled
      */
     public MenuDeleteCommand(Index targetIndex, boolean isForce) {
         this.targetIndex = targetIndex;

--- a/src/main/java/seedu/address/logic/parser/commands/customer/CustomerDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/commands/customer/CustomerDeleteCommandParser.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.parser.commands.customer;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FORCE_DELETE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.customer.CustomerDeleteCommand;
+import seedu.address.logic.commands.menu.MenuDeleteCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.commands.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,9 +23,17 @@ public class CustomerDeleteCommandParser implements Parser<CustomerDeleteCommand
      * @throws ParseException if the user input does not conform the expected format
      */
     public CustomerDeleteCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FORCE_DELETE);
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new CustomerDeleteCommand(index);
+
+            if (argMultimap.getValue(PREFIX_FORCE_DELETE).isEmpty()) {
+                Index index = ParserUtil.parseIndex(args);
+                return new CustomerDeleteCommand(index, false);
+            } else {
+                Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+                return new CustomerDeleteCommand(index, true);
+            }
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CustomerDeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/commands/customer/CustomerDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/commands/customer/CustomerDeleteCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FORCE_DELETE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.customer.CustomerDeleteCommand;
-import seedu.address.logic.commands.menu.MenuDeleteCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -265,9 +265,15 @@ public interface Model {
      */
     void updateFilteredOrderList(Comparator<Order> comparator);
 
+    //@@ author kangtinglee
     /** Returns an list of the orders belonging to a particular customer */
     List<Order> getOrdersFromPerson(Person target);
 
+    //@@ author kangtinglee
+    /** Returns an list of the incomplete orders belonging to a particular customer */
+    List<Order> getIncompleteOrdersFromPerson(Person target);
+
+    /** Mark an order as complete */
     void completeOrder(Order orderToComplete);
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -473,12 +473,25 @@ public class ModelManager implements Model {
     }
 
     //@@author kangtinglee
-    /** Returns an unmodifiable view of the orders belonging to a particular customer */
+    /** Returns an list of the orders belonging to a particular customer */
     public List<Order> getOrdersFromPerson(Person target) {
         List<Order> result = new ArrayList<>();
         ObservableList<Order> orders = getOrderBook().getOrderList();
         for (Order o : orders) {
             if (o.isFromCustomer(target)) {
+                result.add(o);
+            }
+        }
+        return result;
+    }
+
+    //@@author kangtinglee
+    /** Returns an list of the incomplete orders belonging to a particular customer */
+    public List<Order> getIncompleteOrdersFromPerson(Person target) {
+        List<Order> result = new ArrayList<>();
+        List<Order> orders = getOrdersFromPerson(target);
+        for (Order o : orders) {
+            if (o.getState() == Order.State.UNCOMPLETED) {
                 result.add(o);
             }
         }

--- a/src/test/java/seedu/address/logic/commands/CustomerAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CustomerAddCommandTest.java
@@ -334,6 +334,11 @@ public class CustomerAddCommandTest {
         }
 
         @Override
+        public List<Order> getIncompleteOrdersFromPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void completeOrder(Order orderToComplete) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Fix #134 

This introduces a warning in the event that the customer that is being deleted has unfulfilled orders so as to prevent the unknowing deletion of unfulfilled order.