### PR TITLE
Bug Fix for Inventory Commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
@@ -43,14 +43,16 @@ public class InventoryAddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        InventoryCommandUtil.isValidIngredient(toAdd, model);
+
         String message = "";
 
-        if (InventoryCommandUtil.isValidIngredient(toAdd, model)) {
-            model.addIngredient(toAdd);
-            message = String.format(ADD_MESSAGE_SUCCESS, toAdd);
-        }else {
+        if (model.hasIngredient(toAdd)) {
             model.increaseIngredientByName(toAdd.getName(), toAdd.getQuantity());
             message = String.format(INCREASE_MESSAGE_SUCCESS, toAdd);
+        }else {
+            model.addIngredient(toAdd);
+            message = String.format(ADD_MESSAGE_SUCCESS, toAdd);
         }
 
         return new CommandResult(message, CommandResult.CRtype.INGREDIENT);

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
@@ -27,7 +27,8 @@ public class InventoryAddCommand extends Command {
             + PREFIX_NAME + "potato "
             + PREFIX_QUANTITY + "51";
 
-    public static final String MESSAGE_SUCCESS = "New ingredient added: %1$s";
+    public static final String ADD_MESSAGE_SUCCESS = "New ingredient added: %1$s";
+    public static final String INCREASE_MESSAGE_SUCCESS = "Ingredient increased: %1$s";
 
     private final Ingredient toAdd;
 
@@ -42,13 +43,17 @@ public class InventoryAddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        String message = "";
 
         if (InventoryCommandUtil.isValidIngredient(toAdd, model)) {
             model.addIngredient(toAdd);
+            message = String.format(ADD_MESSAGE_SUCCESS, toAdd);
+        }else {
+            model.increaseIngredientByName(toAdd.getName(), toAdd.getQuantity());
+            message = String.format(INCREASE_MESSAGE_SUCCESS, toAdd);
         }
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd),
-                CommandResult.CRtype.INGREDIENT);
+        return new CommandResult(message, CommandResult.CRtype.INGREDIENT);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryAddCommand.java
@@ -50,7 +50,7 @@ public class InventoryAddCommand extends Command {
         if (model.hasIngredient(toAdd)) {
             model.increaseIngredientByName(toAdd.getName(), toAdd.getQuantity());
             message = String.format(INCREASE_MESSAGE_SUCCESS, toAdd);
-        }else {
+        } else {
             model.addIngredient(toAdd);
             message = String.format(ADD_MESSAGE_SUCCESS, toAdd);
         }

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryCommandUtil.java
@@ -16,7 +16,8 @@ public class InventoryCommandUtil {
      */
     public static boolean isValidIngredient(Ingredient ingredient, Model model) throws CommandException {
         if (model.hasIngredient(ingredient)) {
-            throw new CommandException(MESSAGE_DUPLICATE_INGREDIENT);
+//            throw new CommandException(MESSAGE_DUPLICATE_INGREDIENT);
+            return false;
         }
         return true;
     }

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryCommandUtil.java
@@ -5,8 +5,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ingredient.Ingredient;
 
 public class InventoryCommandUtil {
-    public static final String MESSAGE_DUPLICATE_INGREDIENT = "This ingredient already exists in the inventory";
-
+    public static final String MESSAGE_INVALID_QUANTITY = "The quantity entered is invalid, "
+            + "please enter a positive number only!";
     /**
      * Checks whether the Ingredient is a valid entry.
      * @param ingredient Candidate Ingredient to be added.
@@ -15,9 +15,8 @@ public class InventoryCommandUtil {
      * @throws CommandException If the Ingredient is an invalid entry.
      */
     public static boolean isValidIngredient(Ingredient ingredient, Model model) throws CommandException {
-        if (model.hasIngredient(ingredient)) {
-//            throw new CommandException(MESSAGE_DUPLICATE_INGREDIENT);
-            return false;
+        if (ingredient.getQuantity() < 0) {
+            throw new CommandException(MESSAGE_INVALID_QUANTITY);
         }
         return true;
     }

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryDecreaseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryDecreaseCommand.java
@@ -53,7 +53,7 @@ public class InventoryDecreaseCommand extends Command {
 
         if (model.hasIngredient(toDecrease)) {
             model.decreaseIngredient(toDecrease, quantity);
-        }else {
+        } else {
             throw new CommandException(MESSAGE_INVALID_INGREDIENT);
         }
 

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryDecreaseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryDecreaseCommand.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.commands.inventory;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ingredient.Ingredient;
+
+/**
+ * Decreases the quantity of an existing ingredient.
+ */
+public class InventoryDecreaseCommand extends Command {
+
+    public static final String COMPONENT_WORD = "inventory";
+    public static final String COMMAND_WORD = "decrease";
+
+    public static final String MESSAGE_USAGE = COMPONENT_WORD + " " + COMMAND_WORD
+            + ": Decrease the quantity of an existing ingredient in the inventory.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_QUANTITY + "QUANTITY\n"
+            + "Example: " + COMPONENT_WORD + " " + COMMAND_WORD + " "
+            + "1 "
+            + PREFIX_QUANTITY + "2";
+
+    public static final String MESSAGE_SUCCESS = "Ingredient quantity has been decreased: %1$s";
+    public static final String MESSAGE_INVALID_INGREDIENT = "Ingredient was not found in the system, "
+            + "have you added the ingredient to the inventory?";
+
+    private final Index targetIndex;
+    private final int quantity;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public InventoryDecreaseCommand(Index targetIndex, int quantity) {
+        this.targetIndex = targetIndex;
+        this.quantity = quantity;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        Ingredient toDecrease = model.getIngredientByIndex(this.targetIndex.getZeroBased());
+
+        InventoryCommandUtil.isValidIngredient(toDecrease, model);
+
+        String message = "";
+
+        if (model.hasIngredient(toDecrease)) {
+            model.decreaseIngredient(toDecrease, quantity);
+        }else {
+            throw new CommandException(MESSAGE_INVALID_INGREDIENT);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toDecrease.getName()), CommandResult.CRtype.INGREDIENT);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InventoryDecreaseCommand // instanceof handles nulls
+                && targetIndex.equals(((InventoryDecreaseCommand) other).targetIndex));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryEditCommand.java
@@ -63,6 +63,8 @@ public class InventoryEditCommand extends Command {
         Ingredient ingredientToEdit = lastShownList.get(index.getZeroBased());
         Ingredient editedIngredient = createEditedIngredient(ingredientToEdit, editIngredientDescriptor);
 
+        InventoryCommandUtil.isValidIngredient(editedIngredient, model);
+
         if (!ingredientToEdit.isSame(editedIngredient) && model.hasIngredient(editedIngredient)) {
             throw new CommandException(MESSAGE_DUPLICATE_INGREDIENT);
         }

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryEditCommand.java
@@ -23,12 +23,12 @@ public class InventoryEditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMPONENT_WORD + " " + COMMAND_WORD
             + ": Edits the details of the ingredient "
-            + "identified by the index number used in the displayed ingredient list. "
+            + "identified by the index number used in the displayed ingredient list.\n"
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_QUANTITY + "QUANTITY]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example: " + COMPONENT_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Sweetcorn";
 
     public static final String MESSAGE_EDIT_INGREDIENT_SUCCESS = "Edited Ingredient: %1$s";

--- a/src/main/java/seedu/address/logic/parser/commands/inventory/InventoryDecreaseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/commands/inventory/InventoryDecreaseCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser.commands.inventory;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.inventory.InventoryDecreaseCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.commands.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new InventoryDecreaseCommand object
+ */
+public class InventoryDecreaseCommandParser implements Parser<InventoryDecreaseCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public InventoryDecreaseCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_QUANTITY);
+
+        try {
+            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            int quantity = Integer.parseInt(argMultimap.getValue(PREFIX_QUANTITY).get());
+            return new InventoryDecreaseCommand(index, quantity);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, InventoryDecreaseCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/commands/inventory/InventoryEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/commands/inventory/InventoryEditCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.customer.CustomerEditCommand;
 import seedu.address.logic.commands.inventory.InventoryEditCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;

--- a/src/main/java/seedu/address/logic/parser/components/InventoryParser.java
+++ b/src/main/java/seedu/address/logic/parser/components/InventoryParser.java
@@ -10,11 +10,13 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.inventory.InventoryAddCommand;
+import seedu.address.logic.commands.inventory.InventoryDecreaseCommand;
 import seedu.address.logic.commands.inventory.InventoryDeleteCommand;
 import seedu.address.logic.commands.inventory.InventoryEditCommand;
 import seedu.address.logic.commands.inventory.InventoryFindCommand;
 import seedu.address.logic.commands.inventory.InventoryListCommand;
 import seedu.address.logic.parser.commands.inventory.InventoryAddCommandParser;
+import seedu.address.logic.parser.commands.inventory.InventoryDecreaseCommandParser;
 import seedu.address.logic.parser.commands.inventory.InventoryDeleteCommandParser;
 import seedu.address.logic.parser.commands.inventory.InventoryEditCommandParser;
 import seedu.address.logic.parser.commands.inventory.InventoryFindCommandParser;
@@ -55,6 +57,9 @@ public class InventoryParser implements ComponentParser {
 
         case InventoryEditCommand.COMMAND_WORD:
             return new InventoryEditCommandParser().parse(arguments);
+
+        case InventoryDecreaseCommand.COMMAND_WORD:
+            return new InventoryDecreaseCommandParser().parse(arguments);
 
         case InventoryFindCommand.COMMAND_WORD:
             return new InventoryFindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -205,6 +205,13 @@ public interface Model {
     void setIngredient(Ingredient target, Ingredient editedIngredient);
 
     /**
+     * Decrease the ingredient quantity by given quantity
+     * @param target ingredient to be decreased
+     * @param decreaseQuantity the number to decrease the ingredient quantity
+     */
+    public void decreaseIngredient(Ingredient target, int decreaseQuantity);
+
+    /**
      * Decrease the ingredient quantity with the given {@code order}
      * @param order order added
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -211,6 +211,13 @@ public interface Model {
     void decreaseIngredientByOrder(Order order);
 
     /**
+     * Increases an existing ingredient by given quantity
+     * @param name existing ingredient's name
+     * @param increaseQuantity the number to increase the ingredient quantity
+     */
+    void increaseIngredientByName(String name, int increaseQuantity);
+
+    /**
      * Increase the ingredient quantity with the given {@code order}
      * @param order order deleted
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -400,17 +400,27 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Increase the ingredient quantity by given quantity
+     * Increases the ingredient quantity by given quantity
      * @param target ingredient to be increased
-     * @param decreaseQuantity the number to increase the ingredient quantity
+     * @param increaseQuantity the number to increase the ingredient quantity
      */
-    public void increaseIngredient(Ingredient target, int decreaseQuantity) {
-        Ingredient increase = new Ingredient(target.getName(), target.getQuantity() + decreaseQuantity);
+    public void increaseIngredient(Ingredient target, int increaseQuantity) {
+        Ingredient increase = new Ingredient(target.getName(), target.getQuantity() + increaseQuantity);
         this.setIngredient(target, increase);
     }
 
     /**
-     * Increase the ingredient quantity with the given {@code order}
+     * Increases an existing ingredient by given quantity
+     * @param name existing ingredient's name
+     * @param increaseQuantity the number to increase the ingredient quantity
+     */
+    public void increaseIngredientByName(String name, int increaseQuantity) {
+        Ingredient ingredient = ingredientBook.getIngredientByName(name);
+        increaseIngredient(ingredient, increaseQuantity);
+    }
+
+    /**
+     * Increases the ingredient quantity with the given {@code order}
      * @param order order added
      */
     public void increaseIngredientByOrder(Order order) {

--- a/src/main/java/seedu/address/model/ingredient/Ingredient.java
+++ b/src/main/java/seedu/address/model/ingredient/Ingredient.java
@@ -40,7 +40,7 @@ public class Ingredient implements Item {
 
         Ingredient otherIngredient = (Ingredient) other;
         return otherIngredient != null
-                && this.getName().equals(otherIngredient.getName());
+                && this.getName().equalsIgnoreCase(otherIngredient.getName());
     }
 
     @Override
@@ -54,7 +54,7 @@ public class Ingredient implements Item {
         }
 
         Ingredient otherIngredient = (Ingredient) other;
-        return this.name.equals(otherIngredient.name);
+        return this.name.equalsIgnoreCase(otherIngredient.name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,69 +24,63 @@ import seedu.address.model.person.ReadOnlyPersonBook;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
-    static Ingredient potato = new Ingredient("Potato", 50);
-    static Ingredient chicken = new Ingredient("Chicken", 50);
-    static Ingredient lettuce = new Ingredient("Lettuce", 50);
-    static Ingredient beefPatty = new Ingredient("Beef patty", 50);
-    static Ingredient burgerBun = new Ingredient("Burger bun", 30);
+    private static Ingredient potato = new Ingredient("Potato", 50);
+    private static Ingredient chicken = new Ingredient("Chicken", 50);
+    private static Ingredient lettuce = new Ingredient("Lettuce", 50);
+    private static Ingredient beefPatty = new Ingredient("Beef patty", 50);
+    private static Ingredient burgerBun = new Ingredient("Burger bun", 30);
 
-    static Dish potatoSalad = new Dish("Potato salad", 6.50,
+    private static Dish potatoSalad = new Dish("Potato salad", 6.50,
             new ArrayList<Pair<Ingredient, Integer>>(Arrays.asList(
                     new Pair<>(potato, 1),
                     new Pair<>(lettuce, 1)
             )));
-    static Dish burger = new Dish("Burger", 11.50,
+    private static Dish burger = new Dish("Burger", 11.50,
             new ArrayList<Pair<Ingredient, Integer>>(Arrays.asList(
                     new Pair<>(burgerBun, 1),
                     new Pair<>(beefPatty, 1),
                     new Pair<>(lettuce, 1)
             )));
-    static Dish wings = new Dish("Chicken wings", 6.00,
+    private static Dish wings = new Dish("Chicken wings", 6.00,
             new ArrayList<Pair<Ingredient, Integer>>(Arrays.asList(
                     new Pair<>(chicken, 1)
             )));
-    static Dish fries = new Dish("French fries", 5.50,
+    private static Dish fries = new Dish("French fries", 5.50,
             new ArrayList<Pair<Ingredient, Integer>>(Arrays.asList(
                     new Pair<>(potato, 1)
             )));
 
-    static Person alex = new Person("Alex Yeoh", "87438807", "alexyeoh@example.com",
+    private static Person alex = new Person("Alex Yeoh", "87438807", "alexyeoh@example.com",
             "Blk 30 Geylang Street 29, #06-40",
             getTagList("gluten allergy"));
-    static Person bernice = new Person("Bernice Yu", "99272758", "berniceyu@example.com",
+    private static Person bernice = new Person("Bernice Yu", "99272758", "berniceyu@example.com",
             "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
             getTagList("regular", "seafood allergy"));
-    static Person charlotte = new Person("Charlotte Oliveiro", "93210283", "charlotte@example.com",
+    private static Person charlotte = new Person("Charlotte Oliveiro", "93210283", "charlotte@example.com",
             "Blk 11 Ang Mo Kio Street 74, #11-04",
             getTagList("vegan"));
-    static Person david = new Person("David Li", "91031282", "lidavid@example.com",
+    private static Person david = new Person("David Li", "91031282", "lidavid@example.com",
             "Blk 436 Serangoon Gardens Street 26, #16-43",
             getTagList("employee discount"));
-    static Person ibrahim = new Person("Irfan Ibrahim", "92492021", "irfan@example.com",
+    private static Person ibrahim = new Person("Irfan Ibrahim", "92492021", "irfan@example.com",
             "Blk 47 Tampines Street 20, #17-35",
             getTagList("regular"));
-    static Person roy = new Person("Roy Balakrishnan", "92624417", "royb@example.com",
+    private static Person roy = new Person("Roy Balakrishnan", "92624417", "royb@example.com",
             "Blk 45 Aljunied Street 85, #11-31",
             getTagList("regular"));
 
     public static Person[] getSamplePersons() {
-        return new Person[] {
-                alex, bernice, charlotte, david, ibrahim,roy
-        };
+        return new Person[] { alex, bernice, charlotte, david, ibrahim, roy };
     }
 
     public static Dish[] getSampleDishes() {
         // dummy dishes to populate order list
-        return new Dish[] {
-                potatoSalad, burger, wings, fries
-        };
+        return new Dish[] { potatoSalad, burger, wings, fries };
     }
 
 
     public static Ingredient[] getSampleIngredients() {
-        return new Ingredient[] {
-                potato, chicken, lettuce, beefPatty, burgerBun
-        };
+        return new Ingredient[] { potato, chicken, lettuce, beefPatty, burgerBun };
     }
 
     public static Order[] getSampleOrders() {

--- a/src/test/java/seedu/address/logic/commands/CustomerAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CustomerAddCommandTest.java
@@ -265,7 +265,17 @@ public class CustomerAddCommandTest {
         }
 
         @Override
+        public void decreaseIngredient(Ingredient target, int quantity) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void decreaseIngredientByOrder(Order order) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void increaseIngredientByName(String name, int quantity) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
1. Fix #210  - Ingredient name comparison to be not case sensitive. 
2. Fix #212  - 'inventory add' on existing command will correctly increase the quantity instead.
3. Fix #185  - inventory 'add' or 'edit' was able to enter negative value. This fixes #217 as well.
4. Fix #158  - inventory edit will now display the correct error message usage.
5. Fix #157 - inventory decrease is working properly now.