### PR TITLE
Change printed header on PDFs

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "JJIMY";
     font-size: 32px;
   }
 }


### PR DESCRIPTION
When printed to PDFs, UG/DG pages still say "AB-3".

This fix changes that to "JJIMY".